### PR TITLE
Migrate consumer RabbitMQ interaction to TF style

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,6 @@ jobs:
             SatSim.SchedulableSpec,
             SatSim.TargetVectorSpec
             SatSim.Consumer.AMQPSpec,
-            SatSim.ScheduleRepositorySpec
+            SatSim.Core.ScheduleRepositorySpec
       - name: Send coverage report
         uses: codecov/codecov-action@v5

--- a/app/SatSim/Config.hs
+++ b/app/SatSim/Config.hs
@@ -2,6 +2,7 @@
 
 module SatSim.Config where
 
+import Control.Monad.Catch (MonadCatch)
 import SatSim.PubSub (RabbitMQConnectInfo)
 import SatSim.Core.ScheduleRepository (ScheduleRepository, readSchedule, writeSchedule)
 import Control.Monad.Trans.Reader (withReaderT, ReaderT)
@@ -17,5 +18,5 @@ instance MonadIO m => ScheduleRepository (ReaderT ConsumerConfig m) where
   writeSchedule scheduleId schedule =  withReaderT redisScheduleRepository $ writeSchedule scheduleId schedule
   readSchedule = withReaderT redisScheduleRepository . readSchedule
 
-instance BatchStreamSource (ReaderT ConsumerConfig IO) where
+instance (MonadIO m, MonadCatch m) => BatchStreamSource (ReaderT ConsumerConfig m) where
   batches = Stream.morphInner (withReaderT rabbitMQConnectInfo) PubSub.consumeBatches

--- a/app/SatSim/Config.hs
+++ b/app/SatSim/Config.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE FlexibleInstances #-}
+
+module SatSim.Config where
+
+import SatSim.PubSub (RabbitMQConnectInfo)
+import SatSim.Core.ScheduleRepository (ScheduleRepository, readSchedule, writeSchedule)
+import Control.Monad.Trans.Reader (withReaderT, ReaderT)
+import SatSim.Cache (RedisScheduleRepository(..))
+import Control.Monad.IO.Class (MonadIO)
+import SatSim.Core.BatchStreamSource (BatchStreamSource, batches)
+import qualified SatSim.PubSub as PubSub
+import qualified Streamly.Data.Stream as Stream
+
+data ConsumerConfig = ConsumerConfig { rabbitMQConnectInfo :: RabbitMQConnectInfo, redisScheduleRepository :: RedisScheduleRepository }
+
+instance MonadIO m => ScheduleRepository (ReaderT ConsumerConfig m) where
+  writeSchedule scheduleId schedule =  withReaderT redisScheduleRepository $ writeSchedule scheduleId schedule
+  readSchedule = withReaderT redisScheduleRepository . readSchedule
+
+instance BatchStreamSource (ReaderT ConsumerConfig IO) where
+  batches = Stream.morphInner (withReaderT rabbitMQConnectInfo) PubSub.consumeBatches

--- a/schedule-2d-sat-sim.cabal
+++ b/schedule-2d-sat-sim.cabal
@@ -55,8 +55,8 @@ library
 executable schedule-2d-sat-sim
   import:           warnings
   main-is:          Main.hs
+  other-modules:    SatSim.Config
 
-  -- other-modules:
   -- other-extensions:
   build-depends:
     , amqp
@@ -64,6 +64,7 @@ executable schedule-2d-sat-sim
     , hedis
     , optparse-applicative
     , schedule-2d-sat-sim
+    , streamly-core
     , text
     , transformers
 

--- a/schedule-2d-sat-sim.cabal
+++ b/schedule-2d-sat-sim.cabal
@@ -79,9 +79,9 @@ test-suite schedule-2d-sat-sim-test
     SatSim.Algo.GreedySpec
     SatSim.CacheSpec
     SatSim.Consumer.AMQPSpec
+    SatSim.Core.ScheduleRepositorySpec
     SatSim.Gen.ProducerSpec
     SatSim.SchedulableSpec
-    SatSim.ScheduleRepositorySpec
     SatSim.TargetVectorSpec
     SatSim.TestLib
 

--- a/schedule-2d-sat-sim.cabal
+++ b/schedule-2d-sat-sim.cabal
@@ -18,12 +18,12 @@ library
     SatSim.Algo.Greedy
     SatSim.Cache
     SatSim.Consumer.AMQP
+    SatSim.Core.ScheduleRepository
     SatSim.Gen.Producer
     SatSim.Producer.AMQP
     SatSim.Quantities
     SatSim.Satellite
     SatSim.Schedulable
-    SatSim.ScheduleRepository
     SatSim.TargetVector
 
   build-depends:

--- a/schedule-2d-sat-sim.cabal
+++ b/schedule-2d-sat-sim.cabal
@@ -18,9 +18,11 @@ library
     SatSim.Algo.Greedy
     SatSim.Cache
     SatSim.Consumer.AMQP
+    SatSim.Core.BatchStreamSource
     SatSim.Core.ScheduleRepository
     SatSim.Gen.Producer
     SatSim.Producer.AMQP
+    SatSim.PubSub
     SatSim.Quantities
     SatSim.Satellite
     SatSim.Schedulable

--- a/schedule-2d-sat-sim.cabal
+++ b/schedule-2d-sat-sim.cabal
@@ -61,6 +61,7 @@ executable schedule-2d-sat-sim
   build-depends:
     , amqp
     , base                  ^>=4.19
+    , exceptions
     , hedis
     , optparse-applicative
     , schedule-2d-sat-sim

--- a/src/SatSim/Consumer/AMQP.hs
+++ b/src/SatSim/Consumer/AMQP.hs
@@ -5,30 +5,21 @@
 module SatSim.Consumer.AMQP where
 
 import Control.Concurrent (threadDelay)
-import Control.Monad.Catch (MonadCatch)
+import Control.Monad.Catch (MonadThrow)
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Control.Monad.Trans.Control (MonadBaseControl)
-import Data.Aeson (eitherDecode)
 import Data.IntervalIndex (allIntervals)
 import Data.Maybe (fromMaybe)
-import Data.Text (Text)
 import Data.These (These (..))
-import Network.AMQP
-  ( Ack (..),
-    Channel,
-    Message (..),
-    ackEnv,
-  )
-import Network.AMQP.Streamly (consume)
 import SatSim.Algo.Greedy (scheduleOn)
+import SatSim.Core.BatchStreamSource (BatchStreamSource, batches)
+import SatSim.Core.ScheduleRepository (ScheduleRepository (..))
 import SatSim.Quantities (Seconds (..))
 import SatSim.Satellite (Satellite (..))
-import SatSim.Schedulable (Schedulable (..), ScheduleId (..))
-import SatSim.Core.ScheduleRepository (ScheduleRepository (..))
+import SatSim.Schedulable (ScheduleId (..))
 import qualified Streamly.Data.Fold as Fold
 import qualified Streamly.Data.Stream as Stream
 import Streamly.Data.Stream.Prelude (maxThreads, parMergeBy)
-import SatSim.Core.BatchStreamSource (BatchStreamSource, batches)
 
 data Heartbeat m = Heartbeat {unheartbeat :: m (), interval :: Seconds}
 
@@ -40,12 +31,17 @@ beatForever :: (MonadIO m) => Heartbeat m -> Stream.Stream m ()
 beatForever (Heartbeat {unheartbeat, interval}) =
   Stream.repeatM $ unheartbeat *> liftIO (threadDelay . floor . unSeconds . (* 1000000) $ interval)
 
--- build from:
--- made it to the last step 😎
--- consume + schedule + add the hb back
-consumeBatches :: (BatchStreamSource m, ScheduleRepository m, MonadIO m) =>
-  Satellite -> m ()
-consumeBatches satellite =
+consumeBatches ::
+  ( MonadBaseControl IO m,
+    BatchStreamSource m,
+    ScheduleRepository m,
+    MonadIO m,
+    MonadThrow m
+  ) =>
+  Satellite ->
+  Heartbeat IO ->
+  m ()
+consumeBatches satellite heartbeat =
   let scheduleBatch batch = do
         schedule <- fromMaybe mempty <$> readSchedule (ScheduleId "schedule-key")
         let newSchedule = scheduleOn satellite batch schedule
@@ -59,45 +55,6 @@ consumeBatches satellite =
               print ("Schedule size: " <> (show . length . allIntervals) sched)
               print ("Num errors encountered: " <> (show . length) errs)
             writeSchedule (ScheduleId "schedule-key") sched
-   in Stream.fold Fold.drain $ Stream.mapM scheduleBatch batches
-
--- TODO: BatchEventSource m? With instance for ReaderT (Channel, Text) m a?
--- what's the API goal here? I don't want to know anything about m
--- I _do_ want to be able to get a stream of [Schedulable] given a mystery m
--- I don't want Channel/Text as argument types
--- do I want ReaderT m (chan, queue) as the instance, and consumeBatches as bracketing
---   that setup around consume?
-consumeBatchesFromExchange ::
-  (BatchStreamSource m, ScheduleRepository m, MonadIO m, MonadCatch m, MonadBaseControl IO m) =>
-  Satellite ->
-  Channel ->
-  Text ->
-  Heartbeat IO ->
-  m ()
-consumeBatchesFromExchange satellite chan queue hb = do
-  let beat = beatForever . liftHeartbeat $ hb
-  let bracketed = Stream.mapM callback $ consume chan queue Ack
-  let heartbeatingConsumer = parMergeBy (maxThreads 4) (const . const $ EQ) beat bracketed
-  Stream.fold Fold.drain batches
-  where
-    callback (msg, envelope) =
-      let scheduleNewCandidates batch =
-            liftIO (print (show . length $ batch)) *> do
-              schedule <- fromMaybe mempty <$> readSchedule (ScheduleId "schedule-key")
-              let newSchedule = scheduleOn satellite batch schedule
-              case newSchedule of
-                This _ -> liftIO $ putStrLn "nothing scheduled"
-                That sched -> do
-                  liftIO $ print ("Schedule size: " <> (show . length . allIntervals) sched)
-                  writeSchedule (ScheduleId "schedule-key") sched
-                These errs sched -> do
-                  liftIO $ do
-                    print ("Schedule size: " <> (show . length . allIntervals) sched)
-                    print ("Num errors encountered: " <> (show . length) errs)
-                  writeSchedule (ScheduleId "schedule-key") sched
-       in do
-            either
-              (liftIO . putStrLn)
-              scheduleNewCandidates
-              (eitherDecode (msgBody msg) :: Either String [Schedulable])
-            liftIO $ ackEnv envelope
+      beat = beatForever . liftHeartbeat $ heartbeat
+      beatingConsumer = parMergeBy (maxThreads 4) (const . const $ EQ) beat (Stream.mapM scheduleBatch batches)
+   in Stream.fold Fold.drain beatingConsumer

--- a/src/SatSim/Consumer/AMQP.hs
+++ b/src/SatSim/Consumer/AMQP.hs
@@ -39,7 +39,7 @@ beatForever :: (MonadIO m) => Heartbeat m -> Stream.Stream m ()
 beatForever (Heartbeat {unheartbeat, interval}) =
   Stream.repeatM $ unheartbeat *> liftIO (threadDelay . floor . unSeconds . (* 1000000) $ interval)
 
--- TODO: BatchSource m? With instance for ReaderT (Channel, Text) m a?
+-- TODO: BatchEventSource m? With instance for ReaderT (Channel, Text) m a?
 consumeBatchesFromExchange ::
   (ScheduleRepository m, MonadIO m, MonadCatch m, MonadBaseControl IO m) =>
   Satellite ->

--- a/src/SatSim/Consumer/AMQP.hs
+++ b/src/SatSim/Consumer/AMQP.hs
@@ -24,7 +24,7 @@ import SatSim.Algo.Greedy (scheduleOn)
 import SatSim.Quantities (Seconds (..))
 import SatSim.Satellite (Satellite (..))
 import SatSim.Schedulable (Schedulable (..), ScheduleId (..))
-import SatSim.ScheduleRepository (ScheduleRepository (..))
+import SatSim.Core.ScheduleRepository (ScheduleRepository (..))
 import qualified Streamly.Data.Fold as Fold
 import qualified Streamly.Data.Stream as Stream
 import Streamly.Data.Stream.Prelude (maxThreads, parMergeBy)
@@ -40,6 +40,11 @@ beatForever (Heartbeat {unheartbeat, interval}) =
   Stream.repeatM $ unheartbeat *> liftIO (threadDelay . floor . unSeconds . (* 1000000) $ interval)
 
 -- TODO: BatchEventSource m? With instance for ReaderT (Channel, Text) m a?
+-- what's the API goal here? I don't want to know anything about m
+-- I _do_ want to be able to get a stream of [Schedulable] given a mystery m
+-- I don't want Channel/Text as argument types
+-- do I want ReaderT m (chan, queue) as the instance, and consumeBatches as bracketing
+--   that setup around consume?
 consumeBatchesFromExchange ::
   (ScheduleRepository m, MonadIO m, MonadCatch m, MonadBaseControl IO m) =>
   Satellite ->

--- a/src/SatSim/Consumer/AMQP.hs
+++ b/src/SatSim/Consumer/AMQP.hs
@@ -28,6 +28,7 @@ import SatSim.Core.ScheduleRepository (ScheduleRepository (..))
 import qualified Streamly.Data.Fold as Fold
 import qualified Streamly.Data.Stream as Stream
 import Streamly.Data.Stream.Prelude (maxThreads, parMergeBy)
+import SatSim.Core.BatchStreamSource (BatchStreamSource, batches)
 
 data Heartbeat m = Heartbeat {unheartbeat :: m (), interval :: Seconds}
 
@@ -39,6 +40,27 @@ beatForever :: (MonadIO m) => Heartbeat m -> Stream.Stream m ()
 beatForever (Heartbeat {unheartbeat, interval}) =
   Stream.repeatM $ unheartbeat *> liftIO (threadDelay . floor . unSeconds . (* 1000000) $ interval)
 
+-- build from:
+-- made it to the last step 😎
+-- consume + schedule + add the hb back
+consumeBatches :: (BatchStreamSource m, ScheduleRepository m, MonadIO m) =>
+  Satellite -> m ()
+consumeBatches satellite =
+  let scheduleBatch batch = do
+        schedule <- fromMaybe mempty <$> readSchedule (ScheduleId "schedule-key")
+        let newSchedule = scheduleOn satellite batch schedule
+        case newSchedule of
+          This _ -> liftIO $ putStrLn "nothing scheduled"
+          That sched -> do
+            liftIO $ print ("Schedule size: " <> (show . length . allIntervals) sched)
+            writeSchedule (ScheduleId "schedule-key") sched
+          These errs sched -> do
+            liftIO $ do
+              print ("Schedule size: " <> (show . length . allIntervals) sched)
+              print ("Num errors encountered: " <> (show . length) errs)
+            writeSchedule (ScheduleId "schedule-key") sched
+   in Stream.fold Fold.drain $ Stream.mapM scheduleBatch batches
+
 -- TODO: BatchEventSource m? With instance for ReaderT (Channel, Text) m a?
 -- what's the API goal here? I don't want to know anything about m
 -- I _do_ want to be able to get a stream of [Schedulable] given a mystery m
@@ -46,7 +68,7 @@ beatForever (Heartbeat {unheartbeat, interval}) =
 -- do I want ReaderT m (chan, queue) as the instance, and consumeBatches as bracketing
 --   that setup around consume?
 consumeBatchesFromExchange ::
-  (ScheduleRepository m, MonadIO m, MonadCatch m, MonadBaseControl IO m) =>
+  (BatchStreamSource m, ScheduleRepository m, MonadIO m, MonadCatch m, MonadBaseControl IO m) =>
   Satellite ->
   Channel ->
   Text ->
@@ -56,7 +78,7 @@ consumeBatchesFromExchange satellite chan queue hb = do
   let beat = beatForever . liftHeartbeat $ hb
   let bracketed = Stream.mapM callback $ consume chan queue Ack
   let heartbeatingConsumer = parMergeBy (maxThreads 4) (const . const $ EQ) beat bracketed
-  Stream.fold Fold.drain heartbeatingConsumer
+  Stream.fold Fold.drain batches
   where
     callback (msg, envelope) =
       let scheduleNewCandidates batch =

--- a/src/SatSim/Consumer/AMQP.hs
+++ b/src/SatSim/Consumer/AMQP.hs
@@ -15,18 +15,9 @@ import Data.Text (Text)
 import Data.These (These (..))
 import Network.AMQP
   ( Ack (..),
-    ExchangeOpts (..),
+    Channel,
     Message (..),
-    QueueOpts (..),
     ackEnv,
-    bindQueue,
-    closeConnection,
-    declareExchange,
-    declareQueue,
-    newExchange,
-    newQueue,
-    openChannel,
-    openConnection,
   )
 import Network.AMQP.Streamly (consume)
 import SatSim.Algo.Greedy (scheduleOn)
@@ -35,7 +26,6 @@ import SatSim.Satellite (Satellite (..))
 import SatSim.Schedulable (Schedulable (..), ScheduleId (..))
 import SatSim.ScheduleRepository (ScheduleRepository (..))
 import qualified Streamly.Data.Fold as Fold
-import Streamly.Data.Stream (finallyIO)
 import qualified Streamly.Data.Stream as Stream
 import Streamly.Data.Stream.Prelude (maxThreads, parMergeBy)
 
@@ -49,40 +39,35 @@ beatForever :: (MonadIO m) => Heartbeat m -> Stream.Stream m ()
 beatForever (Heartbeat {unheartbeat, interval}) =
   Stream.repeatM $ unheartbeat *> liftIO (threadDelay . floor . unSeconds . (* 1000000) $ interval)
 
+-- TODO: BatchSource m? With instance for ReaderT (Channel, Text) m a?
 consumeBatchesFromExchange ::
   (ScheduleRepository m, MonadIO m, MonadCatch m, MonadBaseControl IO m) =>
   Satellite ->
+  Channel ->
   Text ->
   Heartbeat IO ->
   m ()
-consumeBatchesFromExchange satellite exchangeName' hb = do
-  (conn, chan, queue) <- liftIO $ do
-    conn <- openConnection "127.0.0.1" "/" "guest" "guest"
-    chan <- openChannel conn
-    declareExchange chan (newExchange {exchangeName = exchangeName', exchangeType = "fanout"})
-    (queue, _, _) <- declareQueue chan (newQueue {queueName = "", queueExclusive = True})
-    bindQueue chan queue exchangeName' ""
-    pure (conn, chan, queue)
-
+consumeBatchesFromExchange satellite chan queue hb = do
   let beat = beatForever . liftHeartbeat $ hb
-  let bracketed = finallyIO (closeConnection conn) (Stream.mapM callback $ consume chan queue Ack)
+  let bracketed = Stream.mapM callback $ consume chan queue Ack
   let heartbeatingConsumer = parMergeBy (maxThreads 4) (const . const $ EQ) beat bracketed
   Stream.fold Fold.drain heartbeatingConsumer
   where
     callback (msg, envelope) =
-      let scheduleNewCandidates batch = do
-            schedule <- fromMaybe mempty <$> readSchedule (ScheduleId "schedule-key")
-            let newSchedule = scheduleOn satellite batch schedule
-            case newSchedule of
-              This _ -> liftIO $ putStrLn "nothing scheduled"
-              That sched -> do
-                liftIO $ print ("Schedule size: " <> (show . length . allIntervals) sched)
-                writeSchedule (ScheduleId "schedule-key") sched
-              These errs sched -> do
-                liftIO $ do
-                  print ("Schedule size: " <> (show . length . allIntervals) sched)
-                  print ("Num errors encountered: " <> (show . length) errs)
-                writeSchedule (ScheduleId "schedule-key") sched
+      let scheduleNewCandidates batch =
+            liftIO (print (show . length $ batch)) *> do
+              schedule <- fromMaybe mempty <$> readSchedule (ScheduleId "schedule-key")
+              let newSchedule = scheduleOn satellite batch schedule
+              case newSchedule of
+                This _ -> liftIO $ putStrLn "nothing scheduled"
+                That sched -> do
+                  liftIO $ print ("Schedule size: " <> (show . length . allIntervals) sched)
+                  writeSchedule (ScheduleId "schedule-key") sched
+                These errs sched -> do
+                  liftIO $ do
+                    print ("Schedule size: " <> (show . length . allIntervals) sched)
+                    print ("Num errors encountered: " <> (show . length) errs)
+                  writeSchedule (ScheduleId "schedule-key") sched
        in do
             either
               (liftIO . putStrLn)

--- a/src/SatSim/Core/BatchStreamSource.hs
+++ b/src/SatSim/Core/BatchStreamSource.hs
@@ -4,12 +4,15 @@
 
 module SatSim.Core.BatchStreamSource where
 
-import Control.Monad.Trans.Reader (ReaderT)
+import Control.Monad.Trans.Reader (ReaderT, ask, Reader)
 import SatSim.PubSub (RabbitMQConnectInfo, consumeBatches)
 import SatSim.Schedulable (Schedulable)
 import Streamly.Data.Stream (Stream)
+import qualified Streamly.Data.Stream as Stream
 import Control.Monad.Catch (MonadCatch)
 import Control.Monad.IO.Class (MonadIO)
+
+newtype StaticBatchStream = StaticBatchStream { batchesToEmit :: [[Schedulable]] } deriving (Eq, Show)
 
 class BatchStreamSource m where
   batches :: Stream m [Schedulable]
@@ -17,3 +20,6 @@ class BatchStreamSource m where
 instance (MonadIO m, MonadCatch m) => BatchStreamSource (ReaderT RabbitMQConnectInfo m)
   where
   batches = consumeBatches
+
+instance BatchStreamSource (Reader StaticBatchStream) where
+  batches = Stream.concatMap (Stream.fromList . batchesToEmit) (Stream.fromEffect ask)

--- a/src/SatSim/Core/BatchStreamSource.hs
+++ b/src/SatSim/Core/BatchStreamSource.hs
@@ -8,10 +8,12 @@ import Control.Monad.Trans.Reader (ReaderT)
 import SatSim.PubSub (RabbitMQConnectInfo, consumeBatches)
 import SatSim.Schedulable (Schedulable)
 import Streamly.Data.Stream (Stream)
+import Control.Monad.Catch (MonadCatch)
+import Control.Monad.IO.Class (MonadIO)
 
 class BatchStreamSource m where
   batches :: Stream m [Schedulable]
 
-instance BatchStreamSource (ReaderT RabbitMQConnectInfo IO)
+instance (MonadIO m, MonadCatch m) => BatchStreamSource (ReaderT RabbitMQConnectInfo m)
   where
   batches = consumeBatches

--- a/src/SatSim/Core/BatchStreamSource.hs
+++ b/src/SatSim/Core/BatchStreamSource.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+
+module SatSim.Core.BatchStreamSource where
+
+import Control.Monad.Trans.Reader (ReaderT)
+import SatSim.PubSub (RabbitMQConnectInfo, consumeBatches)
+import SatSim.Schedulable (Schedulable)
+import Streamly.Data.Stream (Stream)
+import qualified Streamly.Data.Stream as Stream
+
+class BatchStreamSource m where
+  batches :: Stream m [Schedulable]
+
+instance
+  (Monad (Stream m0)) =>
+  BatchStreamSource (ReaderT RabbitMQConnectInfo (Stream m0))
+  where
+  batches = Stream.fromEffect consumeBatches

--- a/src/SatSim/Core/BatchStreamSource.hs
+++ b/src/SatSim/Core/BatchStreamSource.hs
@@ -4,18 +4,14 @@
 
 module SatSim.Core.BatchStreamSource where
 
-import Control.Monad.Catch (MonadCatch)
-import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Trans.Reader (ReaderT)
 import SatSim.PubSub (RabbitMQConnectInfo, consumeBatches)
 import SatSim.Schedulable (Schedulable)
 import Streamly.Data.Stream (Stream)
 
-class BatchStreamSource t m where
-  batches :: t (Stream m) [Schedulable]
+class BatchStreamSource m where
+  batches :: Stream m [Schedulable]
 
-instance
-  (MonadCatch m, Monad (Stream m), MonadIO m, MonadIO (Stream m)) =>
-  BatchStreamSource (ReaderT RabbitMQConnectInfo) m
+instance BatchStreamSource (ReaderT RabbitMQConnectInfo IO)
   where
   batches = consumeBatches

--- a/src/SatSim/Core/ScheduleRepository.hs
+++ b/src/SatSim/Core/ScheduleRepository.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
-module SatSim.ScheduleRepository where
+module SatSim.Core.ScheduleRepository where
 
 import Control.Concurrent (modifyMVar_, takeMVar)
 import Control.Monad.IO.Class (MonadIO (liftIO))

--- a/src/SatSim/PubSub.hs
+++ b/src/SatSim/PubSub.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module SatSim.PubSub (consumeBatches, RabbitMQConnectInfo) where
+module SatSim.PubSub (consumeBatches, RabbitMQConnectInfo(..)) where
 
 import Control.Monad.Trans.Reader (ReaderT, ask)
 import Data.Aeson (eitherDecode)

--- a/src/SatSim/PubSub.hs
+++ b/src/SatSim/PubSub.hs
@@ -1,0 +1,17 @@
+module SatSim.PubSub where
+
+import Data.Text (Text)
+import Streamly.Data.Stream (Stream)
+import SatSim.Schedulable (Schedulable)
+import Control.Monad.Trans.Reader (ReaderT)
+
+data RabbitMQConnectInfo = RabbitMQConnectInfo
+  { host :: String,
+    loginUser :: Text,
+    auth :: Text,
+    exchangeName' :: Text
+  }
+  deriving (Eq, Show)
+
+consumeBatches :: ReaderT RabbitMQConnectInfo (Stream m) [Schedulable]
+consumeBatches = undefined

--- a/src/SatSim/PubSub.hs
+++ b/src/SatSim/PubSub.hs
@@ -1,9 +1,35 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
 module SatSim.PubSub where
 
+import Control.Monad.Catch (MonadCatch)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Reader (ReaderT, ask)
+import Data.Aeson (eitherDecode)
 import Data.Text (Text)
-import Streamly.Data.Stream (Stream)
+import Network.AMQP
+  ( Ack (..),
+    Message (..),
+    ackEnv,
+    bindQueue,
+    declareExchange,
+    declareQueue,
+    exchangeName,
+    exchangeType,
+    newExchange,
+    newQueue,
+    openChannel,
+    openConnection,
+    queueExclusive,
+    queueName,
+  )
+import Network.AMQP.Streamly (consume)
 import SatSim.Schedulable (Schedulable)
-import Control.Monad.Trans.Reader (ReaderT)
+import Streamly.Data.Stream (Stream)
+import qualified Streamly.Data.Stream as Stream
 
 data RabbitMQConnectInfo = RabbitMQConnectInfo
   { host :: String,
@@ -13,5 +39,22 @@ data RabbitMQConnectInfo = RabbitMQConnectInfo
   }
   deriving (Eq, Show)
 
-consumeBatches :: ReaderT RabbitMQConnectInfo (Stream m) [Schedulable]
-consumeBatches = undefined
+consumeBatches ::
+  ( MonadCatch m,
+    MonadIO m,
+    MonadIO (Stream m)
+  ) =>
+  ReaderT RabbitMQConnectInfo (Stream m) [Schedulable]
+consumeBatches = do
+  (RabbitMQConnectInfo {host, loginUser, auth, exchangeName'}) <- ask
+  lift $ do
+    conn <- liftIO $ openConnection host "/" loginUser auth
+    chan <- liftIO $ openChannel conn
+    liftIO $ declareExchange chan (newExchange {exchangeName = exchangeName', exchangeType = "fanout"})
+    (queue, _, _) <- liftIO $ declareQueue chan (newQueue {queueName = "", queueExclusive = True})
+    liftIO $ bindQueue chan queue exchangeName' ""
+    consume chan queue Ack >>= \(msg, env) ->
+      Stream.finallyIO (ackEnv env) $
+        case eitherDecode (msgBody msg) of
+          Right batch -> pure batch
+          Left e -> Stream.fromEffect (liftIO $ print e) *> Stream.nil

--- a/test/SatSim/Core/ScheduleRepositorySpec.hs
+++ b/test/SatSim/Core/ScheduleRepositorySpec.hs
@@ -1,4 +1,4 @@
-module SatSim.ScheduleRepositorySpec where
+module SatSim.Core.ScheduleRepositorySpec where
 
 import Control.Concurrent (newMVar)
 import Control.Monad.Trans.Reader (runReaderT)
@@ -12,7 +12,7 @@ import SatSim.Cache (LocalScheduleRepository (..))
 import SatSim.Quantities (Radians (..))
 import SatSim.Satellite (Satellite (..), SatelliteName (..))
 import SatSim.Schedulable (Schedulable (..), ScheduleId (..))
-import SatSim.ScheduleRepository (readSchedule, writeSchedule)
+import SatSim.Core.ScheduleRepository (readSchedule, writeSchedule)
 import SatSim.TargetVector (mkTargetVector)
 import Test.Hspec (Spec, describe, it, shouldBe)
 


### PR DESCRIPTION
Also add a local `BatchStreamSource` that takes a list, for testing reasons.

Closes #21 

Makes #16 a little more doable -- not for testing the AMQP interaction, but to make the consumer itself testable by breaking the dependency on RabbitMQ, _nice_